### PR TITLE
Cancel previous BGTask requests before scheduling

### DIFF
--- a/GlucoseSync/AppDelegate.swift
+++ b/GlucoseSync/AppDelegate.swift
@@ -24,7 +24,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func scheduleGlucoseSync() {
-        let request = BGAppRefreshTaskRequest(identifier: "com.gistrec.glucosesync.refresh")
+        let identifier = "com.gistrec.glucosesync.refresh"
+
+        // Cancel any previously scheduled requests to avoid duplicates
+        BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: identifier)
+        print("🔁 Cancelled existing task requests")
+
+        let request = BGAppRefreshTaskRequest(identifier: identifier)
         request.earliestBeginDate = Date(timeIntervalSinceNow: 60 * 60) // каждый час
 
         do {


### PR DESCRIPTION
## Summary
- Cancel any existing background task requests before scheduling a new glucose sync
- Log task cancellation for debugging

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf26689dc8329b0f137621661a798