### PR TITLE
Handle HealthKit unavailability

### DIFF
--- a/GlucoseSync/ContentView.swift
+++ b/GlucoseSync/ContentView.swift
@@ -136,7 +136,12 @@ class HealthKitViewModel: ObservableObject {
     ) {
         guard HKHealthStore.isHealthDataAvailable(),
               let glucoseType = HKQuantityType.quantityType(forIdentifier: .bloodGlucose)
-        else { return }
+        else {
+            DispatchQueue.main.async {
+                onError("Health data not available")
+            }
+            return
+        }
 
         healthStore.requestAuthorization(toShare: [glucoseType], read: []) { success, error in
             DispatchQueue.main.async {

--- a/GlucoseSync/ContentView.swift
+++ b/GlucoseSync/ContentView.swift
@@ -58,7 +58,7 @@ struct ContentView: View {
                         .disabled(isSyncing)
 
                     Button("Request HealthKit Access") {
-                        viewModel.requestAuthorization(
+                        HealthKitViewModel.shared.requestAuthorization(
                             onSuccess: {
                                 showAuthAlert = true
                             },
@@ -137,9 +137,7 @@ class HealthKitViewModel: ObservableObject {
         guard HKHealthStore.isHealthDataAvailable(),
               let glucoseType = HKQuantityType.quantityType(forIdentifier: .bloodGlucose)
         else {
-            DispatchQueue.main.async {
-                onError("Health data not available")
-            }
+            onError("Health data not available")
             return
         }
 
@@ -148,9 +146,11 @@ class HealthKitViewModel: ObservableObject {
                 if success {
                     print("✅ Access granted")
                     onSuccess()
+                    return
                 } else {
                     print("❌ Error: \(error?.localizedDescription ?? "unknown")")
                     onError("No access to Health API")
+                    return
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Notify clients when HealthKit access is impossible by invoking the error handler in `requestAuthorization`
- Surface HealthKit errors through ContentView's alert path

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf2619fc48329a490c59f42b8dc35