### PR TITLE
Use Keychain for credentials

### DIFF
--- a/GlucoseSync/AppDelegate.swift
+++ b/GlucoseSync/AppDelegate.swift
@@ -46,8 +46,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         // Достаём креды (без UI)
-        let email = UserDefaults.standard.string(forKey: "userEmail") ?? ""
-        let password = UserDefaults.standard.string(forKey: "userPassword") ?? ""
+        let email = KeychainService.shared.get("userEmail") ?? ""
+        let password = KeychainService.shared.get("userPassword") ?? ""
 
         guard !email.isEmpty, !password.isEmpty else {
             print("❌ Missing credentials")

--- a/GlucoseSync/ContentView.swift
+++ b/GlucoseSync/ContentView.swift
@@ -4,8 +4,8 @@ import BackgroundTasks
 
 
 struct ContentView: View {
-    @AppStorage("userEmail") private var email = ""
-    @AppStorage("userPassword") private var password = ""
+    @State private var email: String = ""
+    @State private var password: String = ""
 
     @AppStorage("lastSyncDate") private var lastSyncDate: Double = 0  // Unix timestamp
 
@@ -49,6 +49,9 @@ struct ContentView: View {
                         .background(Color(UIColor.secondarySystemBackground))
                         .cornerRadius(8)
                         .disabled(isSyncing)
+                        .onChange(of: email) { newValue in
+                            KeychainService.shared.set(newValue, for: "userEmail")
+                        }
 
                     SecureField("Password", text: $password)
                         .textContentType(.password)
@@ -56,6 +59,9 @@ struct ContentView: View {
                         .background(Color(UIColor.secondarySystemBackground))
                         .cornerRadius(8)
                         .disabled(isSyncing)
+                        .onChange(of: password) { newValue in
+                            KeychainService.shared.set(newValue, for: "userPassword")
+                        }
 
                     Button("Request HealthKit Access") {
                         viewModel.requestAuthorization(
@@ -106,6 +112,10 @@ struct ContentView: View {
                     .padding(20)
                     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14))
             }
+        }
+        .onAppear {
+            email = KeychainService.shared.get("userEmail") ?? ""
+            password = KeychainService.shared.get("userPassword") ?? ""
         }
         .alert("Done", isPresented: $showAuthAlert) {
             Button("OK", role: .cancel) { }

--- a/GlucoseSync/ContentView.swift
+++ b/GlucoseSync/ContentView.swift
@@ -49,8 +49,8 @@ struct ContentView: View {
                         .background(Color(UIColor.secondarySystemBackground))
                         .cornerRadius(8)
                         .disabled(isSyncing)
-                        .onChange(of: email) { newValue in
-                            KeychainService.shared.set(newValue, for: "userEmail")
+                        .onChange(of: email) {
+                            KeychainService.shared.set(email, for: "userEmail")
                         }
 
                     SecureField("Password", text: $password)
@@ -59,8 +59,8 @@ struct ContentView: View {
                         .background(Color(UIColor.secondarySystemBackground))
                         .cornerRadius(8)
                         .disabled(isSyncing)
-                        .onChange(of: password) { newValue in
-                            KeychainService.shared.set(newValue, for: "userPassword")
+                        .onChange(of: password) {
+                            KeychainService.shared.set(password, for: "userPassword")
                         }
 
                     Button("Request HealthKit Access") {

--- a/GlucoseSync/KeychainService.swift
+++ b/GlucoseSync/KeychainService.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Security
+
+final class KeychainService {
+    static let shared = KeychainService()
+    private init() {}
+
+    @discardableResult
+    func set(_ value: String, for key: String) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+        // Remove existing item if it exists
+        SecItemDelete(query as CFDictionary)
+
+        var attributes = query
+        attributes[kSecValueData as String] = data
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    func get(_ key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var item: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let string = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return string
+    }
+}
+

--- a/GlucoseSync/KeychainService.swift
+++ b/GlucoseSync/KeychainService.swift
@@ -18,6 +18,8 @@ final class KeychainService {
 
         var attributes = query
         attributes[kSecValueData as String] = data
+        // Make credentials readable to background tasks even when the device is locked
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
         let status = SecItemAdd(attributes as CFDictionary, nil)
         return status == errSecSuccess
     }


### PR DESCRIPTION
## Summary
- add small KeychainService to wrap credential storage
- read and write email/password via Keychain instead of UserDefaults
- keep UI bindings in sync with Keychain values

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf26ab6248329a2395816b9b9b7fe