### PR TITLE
Add icons to login fields

### DIFF
--- a/GlucoseSync/ContentView.swift
+++ b/GlucoseSync/ContentView.swift
@@ -34,6 +34,12 @@ struct ContentView: View {
                     Text("Glucose Sync")
                         .font(.largeTitle)
 
+                    Text("Sync your Libre3 glucose readings with Apple Health")
+                        .font(.subheadline)
+                        .multilineTextAlignment(.center)
+                        .foregroundColor(.gray)
+                        .padding(.horizontal)
+
                     if lastSyncDate > 0 {
                         let date = Date(timeIntervalSince1970: lastSyncDate)
                         Text("Last sync: \(formatted(date))")
@@ -47,7 +53,7 @@ struct ContentView: View {
                             .scaledToFit()
                             .frame(width: 20, height: 20)
                             .foregroundColor(.gray)
-                        TextField("Email (LibreLinkUp)", text: $email)
+                        TextField("Email", text: $email)
                             .textContentType(.emailAddress)
                             .autocapitalization(.none)
                             .keyboardType(.emailAddress)
@@ -88,7 +94,8 @@ struct ContentView: View {
                             }
                         )
                     }
-                    .buttonStyle(.borderedProminent)
+                    .cornerRadius(8)
+                    .buttonStyle(.bordered)
                     .disabled(isSyncing)
 
                     Button("Sync Glucose from Server") {
@@ -107,7 +114,8 @@ struct ContentView: View {
                             }
                         )
                     }
-                    .buttonStyle(.bordered)
+                    .cornerRadius(8)
+                    .buttonStyle(.borderedProminent)
                     .disabled(isSyncing)
                 }
                 .padding()

--- a/GlucoseSync/ContentView.swift
+++ b/GlucoseSync/ContentView.swift
@@ -41,27 +41,35 @@ struct ContentView: View {
                             .foregroundColor(.gray)
                     }
 
-                    TextField("Email (LibreLinkUp)", text: $email)
-                        .textContentType(.emailAddress)
-                        .autocapitalization(.none)
-                        .keyboardType(.emailAddress)
-                        .padding()
-                        .background(Color(UIColor.secondarySystemBackground))
-                        .cornerRadius(8)
-                        .disabled(isSyncing)
-                        .onChange(of: email) {
-                            KeychainService.shared.set(email, for: "userEmail")
-                        }
+                    HStack {
+                        Image(systemName: "envelope")
+                            .foregroundColor(.gray)
+                        TextField("Email (LibreLinkUp)", text: $email)
+                            .textContentType(.emailAddress)
+                            .autocapitalization(.none)
+                            .keyboardType(.emailAddress)
+                    }
+                    .padding()
+                    .background(Color(UIColor.secondarySystemBackground))
+                    .cornerRadius(8)
+                    .disabled(isSyncing)
+                    .onChange(of: email) {
+                        KeychainService.shared.set(email, for: "userEmail")
+                    }
 
-                    SecureField("Password", text: $password)
-                        .textContentType(.password)
-                        .padding()
-                        .background(Color(UIColor.secondarySystemBackground))
-                        .cornerRadius(8)
-                        .disabled(isSyncing)
-                        .onChange(of: password) {
-                            KeychainService.shared.set(password, for: "userPassword")
-                        }
+                    HStack {
+                        Image(systemName: "lock")
+                            .foregroundColor(.gray)
+                        SecureField("Password", text: $password)
+                            .textContentType(.password)
+                    }
+                    .padding()
+                    .background(Color(UIColor.secondarySystemBackground))
+                    .cornerRadius(8)
+                    .disabled(isSyncing)
+                    .onChange(of: password) {
+                        KeychainService.shared.set(password, for: "userPassword")
+                    }
 
                     Button("Request HealthKit Access") {
                         HealthKitViewModel.shared.requestAuthorization(

--- a/GlucoseSync/ContentView.swift
+++ b/GlucoseSync/ContentView.swift
@@ -43,6 +43,9 @@ struct ContentView: View {
 
                     HStack {
                         Image(systemName: "envelope")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 20, height: 20)
                             .foregroundColor(.gray)
                         TextField("Email (LibreLinkUp)", text: $email)
                             .textContentType(.emailAddress)
@@ -59,6 +62,9 @@ struct ContentView: View {
 
                     HStack {
                         Image(systemName: "lock")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 20, height: 20)
                             .foregroundColor(.gray)
                         SecureField("Password", text: $password)
                             .textContentType(.password)


### PR DESCRIPTION
## Summary
- show mail and lock SF Symbol icons next to login fields for clarity

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfa5a317c8329aea954a5f9711b0c